### PR TITLE
Mileage on Explore Page

### DIFF
--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -16,9 +16,9 @@ export default class HomePage extends Component {
                     </div>
                     <div className="home-body">
                         <h1 className="home-page-title">The Kanawha Trace</h1>
-                        <p>The Kanawha Trace is a 31.68-mile foot trail running from Barboursville, WV, at the confluence of Mud and Guyandotte Rivers, to Frazier's Bottom, WV on the Kanawha River. With the exception of public roads, the trail is located in its entirety on private property. Without the cooperation of these land owners there would be no Kanawha Trace. When hiking the trail please respect the property and interests of these gracious people.
+                        <p className="home-page-intro">The Kanawha Trace is an approximately 32-mile foot trail running from Barboursville, WV, at the confluence of the Mud and Guyandotte Rivers, to Frazier's Bottom, WV on the Kanawha River. With the exception of public roads, the trail is located in its entirety on private property. Without the cooperation of these land owners there would be no Kanawha Trace. When hiking the trail please respect the property and interests of these gracious people.</p>
 
-        The Kanawha Trace starts at the ford crossing of the Mud River on the route of the old James and Kanawha River Turnpike. Today it is known as Merritts Creek Road near Barboursville. The Kanawha Trace runs through 3 counties in West Virginia (Cabell, Mason, Putnam county) and is located currently all on private property. The trail was built and is currently maintained by a local Boy Scout Troop 42 of the Tri-State Area Council. The trail was opened in 1962 and in 2002 we celebrated the 40th Anniversary with more than 300 hikers hiking across all 32 miles.</p>
+                        <p className="home-page-intro">The Kanawha Trace begins at the ford crossing of the Mud River on the route of the old James and Kanawha River Turnpike. Today it is known as Merritts Creek Road near Barboursville. The Kanawha Trace runs through 3 counties in West Virginia (Cabell, Mason, Putnam county) and was built and is currently maintained by a local Boy Scout Troop 42 of the Tri-State Area Council. The trail was opened in 1962 and in 2017 we celebrated the 55th Anniversary with more than 100 hikers hiking across all 32 miles.</p>
                     </div>
 
                 </div>

--- a/src/components/KanawhaTrace.css
+++ b/src/components/KanawhaTrace.css
@@ -36,6 +36,10 @@
 
 }
 
+.home-page-intro{
+margin-bottom: 1em;
+}
+
 .p-button-success{
     background-color: var(--success) !important
 

--- a/src/components/explore/Explore.css
+++ b/src/components/explore/Explore.css
@@ -49,6 +49,14 @@
 
 }
 
+.exp-mileage{
+    margin-top:15px;
+    font-weight: bold;
+    color: var(--darker-green-text-color);
+    font-style: italic;
+
+}
+
 .exp-dd-submit-btn-cont{
     display: flex;
     flex-direction: row;

--- a/src/components/explore/Explore.js
+++ b/src/components/explore/Explore.js
@@ -16,23 +16,41 @@ export default class Explore extends Component {
             start: null,
             end: null,
             message: "",
-            userId: parseInt(sessionStorage.getItem("credentials"))
+            userId: parseInt(sessionStorage.getItem("credentials")),
+            mileage: ""
 
         };
         // Bind functions to this component
         this.onStartChange = this.onStartChange.bind(this);
         this.onEndChange = this.onEndChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
+        this.calculateMileage = this.calculateMileage.bind(this);
 
     }
 
     // these functions are called as the dropdown select changes
     onStartChange(e) {
+
         this.setState({ start: e.value });
+        this.calculateMileage(e.value, this.state.end)
     }
 
     onEndChange(e) {
         this.setState({ end: e.value });
+        this.calculateMileage(this.state.start, e.value)
+    }
+
+    calculateMileage(start, end) {
+        if (start !== null && end !== null) {
+
+            let mileage = Math.abs(start.mile - end.mile).toFixed(2)
+            this.setState({ mileage: mileage })
+        }
+        else{
+
+        }
+
+
     }
 
     // this function is called when the submit button is clicked
@@ -95,7 +113,7 @@ export default class Explore extends Component {
                                 onChange={this.onEndChange}
                                 style={{ width: '300px' }} placeholder="Select an End Point" optionLabel="name" /></div>
                             <div className="exp-dd-foot">{this.state.end ? 'Selected end: ' + this.state.end.name : 'No end point selected'}</div>
-
+                            <div className="exp-mileage">{(this.state.mileage? `Selected route is ${this.state.mileage} miles`:"")}</div>
                         </div>
 
 
@@ -107,11 +125,11 @@ export default class Explore extends Component {
                         {/* Renders conditionally to give user links to their new routes and all routes */}
                         {this.state.message === "Your route was created!" ?
                             <React.Fragment><div><Link to={`/routes/${this.state.newRouteId}`}>Click to see your new Route</Link></div>
-                                <div><Link className="link"to="/routes">Click to see all Routes</Link></div>
+                                <div><Link className="link" to="/routes">Click to see all Routes</Link></div>
                             </React.Fragment> : ""}
                     </div>
                     <div className="exp-right">
-                    {/* call the map component to render the map */}
+                        {/* call the map component to render the map */}
                         <Map className="map-container" waypoints={this.props.waypoints} />
 
                     </div>

--- a/src/components/routes/RouteSearchBar.js
+++ b/src/components/routes/RouteSearchBar.js
@@ -7,8 +7,7 @@ return(
 <span className={`p-float-label ${valueParam}`}>
 <InputText id={valueParam} style = {valueParam ==="searchPlan"?{"width": "85%"}:{"width": "50%"}}
         value={value}
-        onChange={(e)=>{onChange(valueParam,e)}} placeholder={(valueParam==="searchPlan"? "Search for Routes by Name":"Search for Routes by Name or Date")}/>
-    {/* <label htmlFor="in">{(valueParam==="searchPlan"? "Search for Routes by Name":"Search for Routes by Name or Date")}</label> */}
+        onChange={(e)=>{onChange(valueParam,e)}} placeholder={(valueParam==="searchPlan"? "Search for Planned Routes by Name":"Search for Completed Routes by Name or Date Completed")}/>
 </span>
 </React.Fragment>
 )


### PR DESCRIPTION
Logic added to calculate the mileage when a start and end point are selected on the explore page.  Mileage updates as user changes start or end points.  

You should see:  A mileage value above the submit button.  It should only be a positive number with 2 decimal points.  it should not appear unless the start and end points are both selected.  If the same start and end point are selected, it will be 0.00 miles.